### PR TITLE
Restructuring database models for articles with new join table

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,6 @@
 class Article < ApplicationRecord
   belongs_to :user
-  belongs_to :original, class_name: "Article", optional: true
-  belongs_to :unbiased, class_name: "Article", optional: true
+  belongs_to :article_version, optional: true
 
   def generate_json
     response_title = "<h1>#{self.title}</h1>"

--- a/app/models/article_version.rb
+++ b/app/models/article_version.rb
@@ -1,0 +1,4 @@
+class ArticleVersion < ApplicationRecord
+  belongs_to :original, class_name: "Article"
+  belongs_to :unbiased, class_name: "Article", optional: true
+end

--- a/app/services/Llm.rb
+++ b/app/services/Llm.rb
@@ -38,11 +38,16 @@ class Llm
       title = message.split("\n").first
       content = message[title.length...]
       title = title[1...]
-      { url: @article.url, title: title, content: content, user_id: @article.user_id, original_id: @article.id }
+      {
+        url: @article.url,
+        title: title,
+        content: content,
+        user_id: @article.user_id,
+        article_version_id: @article[:article_version_id]
+      }
     else
       unparsed_json = message.split("\n").first
-      puts(unparsed_json)
-      terms_array = JSON.parse(unparsed_json)
+      parsed_json = JSON.parse(unparsed_json)
     end
   end
 end

--- a/db/migrate/20240820191106_remove_original_from_articles.rb
+++ b/db/migrate/20240820191106_remove_original_from_articles.rb
@@ -1,0 +1,5 @@
+class RemoveOriginalFromArticles < ActiveRecord::Migration[7.2]
+  def change
+    remove_reference :articles, :original, null: false, foreign_key: { to_table: :articles }
+  end
+end

--- a/db/migrate/20240820191241_remove_unbiased_from_articles.rb
+++ b/db/migrate/20240820191241_remove_unbiased_from_articles.rb
@@ -1,0 +1,5 @@
+class RemoveUnbiasedFromArticles < ActiveRecord::Migration[7.2]
+  def change
+    remove_reference :articles, :unbiased, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/migrate/20240820191944_create_article_version.rb
+++ b/db/migrate/20240820191944_create_article_version.rb
@@ -1,0 +1,10 @@
+class CreateArticleVersion < ActiveRecord::Migration[7.2]
+  def change
+    create_table :article_versions do |t|
+      t.references :original, null: false, foreign_key: { to_table: :articles }
+      t.references :unbiased, null: false, foreign_key: { to_table: :articles }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240820192126_add_article_version_ref_to_articles.rb
+++ b/db/migrate/20240820192126_add_article_version_ref_to_articles.rb
@@ -1,0 +1,5 @@
+class AddArticleVersionRefToArticles < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :articles, :article_versions, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240820203840_remove_article_version_from_article.rb
+++ b/db/migrate/20240820203840_remove_article_version_from_article.rb
@@ -1,0 +1,5 @@
+class RemoveArticleVersionFromArticle < ActiveRecord::Migration[7.2]
+  def change
+    remove_reference :articles, :article_versions, null: false, foreign_key: { to_table: :article_versions }
+  end
+end

--- a/db/migrate/20240820204121_add_article_version_to_article.rb
+++ b/db/migrate/20240820204121_add_article_version_to_article.rb
@@ -1,0 +1,5 @@
+class AddArticleVersionToArticle < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :articles, :article_version, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20240820205859_change_null_references_in_article_versions.rb
+++ b/db/migrate/20240820205859_change_null_references_in_article_versions.rb
@@ -1,0 +1,6 @@
+class ChangeNullReferencesInArticleVersions < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :article_versions, :original_id, true
+    change_column_null :article_versions, :unbiased_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_19_193035) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_20_205859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,21 +42,37 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_19_193035) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "article_versions", force: :cascade do |t|
+    t.bigint "original_id"
+    t.bigint "unbiased_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["original_id"], name: "index_article_versions_on_original_id"
+    t.index ["unbiased_id"], name: "index_article_versions_on_unbiased_id"
+  end
+
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.string "url"
     t.bigint "user_id", null: false
-    t.bigint "original_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "content"
-    t.bigint "unbiased_id"
     t.integer "bias_score"
     t.integer "shock_score"
     t.string "top_biased_words", default: [], array: true
-    t.index ["original_id"], name: "index_articles_on_original_id"
-    t.index ["unbiased_id"], name: "index_articles_on_unbiased_id"
+    t.bigint "article_version_id"
+    t.index ["article_version_id"], name: "index_articles_on_article_version_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "original_unbiaseds", force: :cascade do |t|
+    t.bigint "original_id", null: false
+    t.bigint "unbiased_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["original_id"], name: "index_original_unbiaseds_on_original_id"
+    t.index ["unbiased_id"], name: "index_original_unbiaseds_on_unbiased_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -68,7 +84,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_19_193035) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "articles", "articles", column: "original_id"
+  add_foreign_key "article_versions", "articles", column: "original_id"
+  add_foreign_key "article_versions", "articles", column: "unbiased_id"
+  add_foreign_key "articles", "article_versions"
   add_foreign_key "articles", "users"
-  add_foreign_key "articles", "users", column: "unbiased_id"
+  add_foreign_key "original_unbiaseds", "articles", column: "original_id"
+  add_foreign_key "original_unbiaseds", "articles", column: "unbiased_id"
 end

--- a/test/fixtures/article_versions.yml
+++ b/test/fixtures/article_versions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  original: one
+  unbiased: one
+
+two:
+  original: two
+  unbiased: two

--- a/test/models/article_version_test.rb
+++ b/test/models/article_version_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticleVersionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The join table ArticleVersions contains records of article pairs. This will be the model that holds comments and can be reshared. The articles now hold a reference to ArticleVersions